### PR TITLE
Restore set_fake_server_info, update to new IP API

### DIFF
--- a/godotsteam/godotsteam_uncommon.h
+++ b/godotsteam/godotsteam_uncommon.h
@@ -30,7 +30,7 @@ public:
 	void indicate_achiv_progress(const String& aName,int pCurrent,int pMax);
 	void reset_all_stats(bool achivsToo=true);
 	// Server/Game info
-//	void set_fake_server_info(const String& server_ip, int port);
+	void set_fake_server_info(const String& server_ip, int port);
 	void set_game_info(const String& s_key, const String& s_value);
 	void clear_game_info();
 	// Overlay


### PR DESCRIPTION
This patch will compile with the new 2.1.2 API (fixes #11) .
The problem is that of course enabling this will break the build on the older versions.

In any case, thank you for your work on this module! :trophy: 

**NOTE:** I haven't been able to test that the feature actually works yet, but the logic is the same, I only fixed the compile error.